### PR TITLE
swipe disable direction

### DIFF
--- a/CardStack.js
+++ b/CardStack.js
@@ -80,7 +80,7 @@ export default class CardStack extends Component {
             this.props.onSwipedTop(sindex);
             this._nextCard('top', gestureState.dx, swipeDirection, 200);
           }
-          else if (!disableBottomSwipe)
+          else if (swipeDirection > 0 && !disableBottomSwipe)
           {
             this.props.onSwipedBottom(sindex);
             this._nextCard('bottom', gestureState.dx, swipeDirection, 200);
@@ -99,7 +99,7 @@ export default class CardStack extends Component {
           {
             this._nextCard('left', swipeDirection, gestureState.dy, 200);
           }
-          else if(!disableRightSwipe)
+          else if(swipeDirection > 0 && !disableRightSwipe)
           {
             this.props.onSwipedRight(sindex);
             this._nextCard('right', swipeDirection, gestureState.dy, 200);


### PR DESCRIPTION
Added swipeDirection > 0, because it was always going to else if(){} and not in else{}, and would be like the user did oposite swipe. 

example: 
when user only disabled TopSwipe, swiping upwards would detect like BottomSwipe, same goes for Left and Right, it would call oposite function, and not reset card to start position.

With this edit, after tests this is now working as expected, disabled one direction only effects that direction, and will return card in starting position when swiping in that direction.

