### PR TITLE
Add initialize deck method

### DIFF
--- a/CardStack.js
+++ b/CardStack.js
@@ -121,7 +121,20 @@ export default class CardStack extends Component {
   }
 
   componentDidMount(){
+    this.initDeck();
+  }
 
+  componentWillReceiveProps(nextProps){
+    if (nextProps.children !== this.props.children) {
+      this.setState({
+        cards: nextProps.children,
+        cardA: nextProps.children[(this.state.topCard=='cardA')? this.state.sindex-2 : this.state.sindex-1],
+        cardB: nextProps.children[(this.state.topCard=='cardB')? this.state.sindex-2 : this.state.sindex-1]
+      });
+    }
+  }
+
+  initDeck() {
     // check if we only have 1 child
     if(typeof this.props.children !== 'undefined' && !Array.isArray(this.props.children)){
       this.setState({
@@ -136,17 +149,6 @@ export default class CardStack extends Component {
         cardA: this.props.children[0],
         cardB: this.props.children[1],
         sindex: 2,
-      });
-    }
-
-  }
-
-  componentWillReceiveProps(nextProps){
-    if (nextProps.children !== this.props.children) {
-      this.setState({
-        cards: nextProps.children,
-        cardA: nextProps.children[(this.state.topCard=='cardA')? this.state.sindex-2 : this.state.sindex-1],
-        cardB: nextProps.children[(this.state.topCard=='cardB')? this.state.sindex-2 : this.state.sindex-1]
       });
     }
   }


### PR DESCRIPTION
The Deck is only initialized once the component is Mounted. However, i'm in a case where I can actually delete a card from my array of cards. The deck will re-render but wont re-initialize, wich is causing a bug once i go back to it.

It should be nice to be able to call a 'initDeck' method on the ref, on order to re-init the deck once we for example deleted an object from our array and want the deck to re-init.