### PR TITLE
Fix Android Touch On Card

### DIFF
--- a/CardStack.js
+++ b/CardStack.js
@@ -389,7 +389,9 @@ export default class CardStack extends Component {
               }}>
               {cardB}
           </Animated.View>
-          <Animated.View style={{
+          <Animated.View
+              pointerEvents={topCard === 'cardA' ? "auto" : "none"}
+              style={{
                 position: 'absolute',
                 ...Platform.select({
                   ios: {


### PR DESCRIPTION
We have two Views to render two cards (A and B), view for A is always on top of B semantically speaking. When the topCard is B, we play with the z-index / elevation to put it **visually** on top of the card A. But react still consider the A on top of everything.

Problem with Android: if we want to add a touchable inside a custom Card, let's say for a "onTap" feature, the click will always been catched by the second Animated.View, no matter the elevation. Z-index works fine with IOS.
The workarround I used is to simply bypass the click event on the card A when the top card is B.