### PR TITLE
fix(types): swipe thresholds bool to number

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ import CardStack, { Card } from 'react-native-card-stack-swiper';
 | disableRightSwipe   | bool          | disable right swipe             |               | false         |
 | verticalSwipe       | bool          | enable/disable vertical swiping |               | true          |
 | horizontalSwipe     | bool          | enable/disable horizont swiping |               | true          |
-| verticalThreshold   | bool          | vertical swipe threshold        |               | height/4      |
-| horizontalThreshold | bool          | horizontal swipe threshold      |               | width/2       |
+| verticalThreshold   | number        | vertical swipe threshold        |               | height/4      |
+| horizontalThreshold | number        | horizontal swipe threshold      |               | width/2       |
 | outputRotationRange | array         | rotation values for the x values|               | ['-15deg', '0deg', '15deg'] |
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,8 +12,8 @@ export interface CardStackProps {
   disableRightSwipe?: boolean;
   verticalSwipe?: boolean;
   horizontalSwipe?: boolean;
-  verticalThreshold?: boolean;
-  horizontalThreshold?: boolean;
+  verticalThreshold?: number;
+  horizontalThreshold?: number;
   outputRotationRange?: [string, string, string]
   onSwipeStart?: (index: number) => void;
   onSwipeEnd?: (index: number) => void; 


### PR DESCRIPTION
Changes the `horizontalThreshold` and `verticalThreshold` types to correctly be numbers. Updates documentation also.