### PR TITLE
handle terminated swipes

### DIFF
--- a/CardStack.js
+++ b/CardStack.js
@@ -66,62 +66,65 @@ class CardStack extends Component {
         this.state.drag.setValue({ x: (horizontalSwipe) ? gestureState.dx : 0, y: (verticalSwipe) ? gestureState.dy : 0 });
       },
       onPanResponderTerminationRequest: (evt, gestureState) => true,
-      onPanResponderRelease: (evt, gestureState) => {
-        this.props.onSwipeEnd();
-        const currentTime = new Date().getTime();
-        const swipeDuration = currentTime - this.state.touchStart;
-        const {
-          verticalThreshold,
-          horizontalThreshold,
-          disableTopSwipe,
-          disableLeftSwipe,
-          disableRightSwipe,
-          disableBottomSwipe,
-        } = this.props;
-
-        if (((Math.abs(gestureState.dx) > horizontalThreshold) ||
-          (Math.abs(gestureState.dx) > horizontalThreshold * 0.6 &&
-            swipeDuration < 150)
-        ) && this.props.horizontalSwipe) {
-
-          const swipeDirection = (gestureState.dx < 0) ? width * -1.5 : width * 1.5;
-          if (swipeDirection < 0 && !disableLeftSwipe) {
-            this._nextCard('left', swipeDirection, gestureState.dy, this.props.duration);
-          }
-          else if (swipeDirection > 0 && !disableRightSwipe) {
-            this._nextCard('right', swipeDirection, gestureState.dy, this.props.duration);
-          }
-          else {
-            this._resetCard();
-          }
-        } else if (((Math.abs(gestureState.dy) > verticalThreshold) ||
-          (Math.abs(gestureState.dy) > verticalThreshold * 0.8 &&
-            swipeDuration < 150)
-        ) && this.props.verticalSwipe) {
-
-          const swipeDirection = (gestureState.dy < 0) ? height * -1 : height;
-          if (swipeDirection < 0 && !disableTopSwipe) {
-
-            this._nextCard('top', gestureState.dx, swipeDirection, this.props.duration);
-          }
-          else if (swipeDirection > 0 && !disableBottomSwipe) {
-            this._nextCard('bottom', gestureState.dx, swipeDirection, this.props.duration);
-          }
-          else {
-            this._resetCard();
-          }
-        }
-        else {
-          this._resetCard();
-        }
-      },
-      onPanResponderTerminate: (evt, gestureState) => {
-      },
+      onPanResponderRelease: this.didTerminateOrRelease,
+      onPanResponderTerminate: this.didTerminateOrRelease,
       onShouldBlockNativeResponder: (evt, gestureState) => {
         return true;
       },
     });
   }
+
+
+
+  didTerminateOrRelease = (evt, gestureState) => {
+    this.props.onSwipeEnd();
+    const currentTime = new Date().getTime();
+    const swipeDuration = currentTime - this.state.touchStart;
+    const {
+      verticalThreshold,
+      horizontalThreshold,
+      disableTopSwipe,
+      disableLeftSwipe,
+      disableRightSwipe,
+      disableBottomSwipe,
+    } = this.props;
+
+    if (((Math.abs(gestureState.dx) > horizontalThreshold) ||
+      (Math.abs(gestureState.dx) > horizontalThreshold * 0.6 &&
+        swipeDuration < 150)
+    ) && this.props.horizontalSwipe) {
+
+      const swipeDirection = (gestureState.dx < 0) ? width * -1.5 : width * 1.5;
+      if (swipeDirection < 0 && !disableLeftSwipe) {
+        this._nextCard('left', swipeDirection, gestureState.dy, this.props.duration);
+      }
+      else if (swipeDirection > 0 && !disableRightSwipe) {
+        this._nextCard('right', swipeDirection, gestureState.dy, this.props.duration);
+      }
+      else {
+        this._resetCard();
+      }
+    } else if (((Math.abs(gestureState.dy) > verticalThreshold) ||
+      (Math.abs(gestureState.dy) > verticalThreshold * 0.8 &&
+        swipeDuration < 150)
+    ) && this.props.verticalSwipe) {
+
+      const swipeDirection = (gestureState.dy < 0) ? height * -1 : height;
+      if (swipeDirection < 0 && !disableTopSwipe) {
+
+        this._nextCard('top', gestureState.dx, swipeDirection, this.props.duration);
+      }
+      else if (swipeDirection > 0 && !disableBottomSwipe) {
+        this._nextCard('bottom', gestureState.dx, swipeDirection, this.props.duration);
+      }
+      else {
+        this._resetCard();
+      }
+    }
+    else {
+      this._resetCard();
+    }
+  };
 
   componentDidUpdate(prevProps) {
     if (typeof this.props.children === 'undefined') return;


### PR DESCRIPTION
Not sure if this is just because of how I am using this component but the swipe is often terminated if someone is swiping slow. Currently the result is the card being stuck in place. This change causes it to be handled in the same way as releasing it. 