### PR TITLE
Fixed useNativeDriver warning issue

### DIFF
--- a/CardStack.js
+++ b/CardStack.js
@@ -188,6 +188,7 @@ class CardStack extends Component {
       {
         toValue: 0,
         duration: this.props.duration,
+        useNativeDriver: this.props.useNativeDriver || false,
       }
     ).start();
     Animated.spring(
@@ -195,6 +196,7 @@ class CardStack extends Component {
       {
         toValue: { x: 0, y: 0 },
         duration: this.props.duration,
+        useNativeDriver: this.props.useNativeDriver || false,
       }
     ).start();
   }
@@ -271,6 +273,7 @@ class CardStack extends Component {
         {
           toValue: 0,
           duration: this.props.duration,
+          useNativeDriver: this.props.useNativeDriver || false,
         }
       ).start();
 
@@ -279,6 +282,7 @@ class CardStack extends Component {
         {
           toValue: { x: 0, y: 0 },
           duration: this.props.duration,
+          useNativeDriver: this.props.useNativeDriver || false,
         }
       ).start();
     })
@@ -320,6 +324,7 @@ class CardStack extends Component {
         {
           toValue: 220,
           duration,
+          useNativeDriver: this.props.useNativeDriver || false,
         }
       ).start();
 
@@ -328,6 +333,7 @@ class CardStack extends Component {
         {
           toValue: { x: (horizontalSwipe) ? x : 0, y: (verticalSwipe) ? y : 0 },
           duration,
+          useNativeDriver: this.props.useNativeDriver || false,
         }
       ).start(() => {
 


### PR DESCRIPTION
useNativeDriver must be specified explicitly now, so added it to props and default value will be false.