### PR TITLE
Adds onSwipeCancel

### DIFF
--- a/CardStack.js
+++ b/CardStack.js
@@ -92,6 +92,7 @@ class CardStack extends Component {
             this._nextCard('right', swipeDirection, gestureState.dy, this.props.duration);
           }
           else {
+            this.props.onSwipeCancel()
             this._resetCard();
           }
         } else if (((Math.abs(gestureState.dy) > verticalThreshold) ||
@@ -108,10 +109,12 @@ class CardStack extends Component {
             this._nextCard('bottom', gestureState.dx, swipeDirection, this.props.duration);
           }
           else {
+            this.props.onSwipeCancel()
             this._resetCard();
           }
         }
         else {
+          this.props.onSwipeCancel()
           this._resetCard();
         }
       },
@@ -142,7 +145,7 @@ class CardStack extends Component {
   }
 
   _getIndex(index, cards){
-    return this.props.loop ? 
+    return this.props.loop ?
       this.mod(index, cards):
       index;
   }
@@ -475,6 +478,7 @@ CardStack.propTypes = {
   renderNoMoreCards: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
   onSwipeStart: PropTypes.func,
   onSwipeEnd: PropTypes.func,
+  onSwipeCancel: PropTypes.func,
   onSwiped: PropTypes.func,
   onSwipedLeft: PropTypes.func,
   onSwipedRight: PropTypes.func,
@@ -507,6 +511,7 @@ CardStack.defaultProps = {
   renderNoMoreCards: () => { return (<Text>No More Cards</Text>) },
   onSwipeStart: () => null,
   onSwipeEnd: () => null,
+  onSwipeCancel: () => null,
   onSwiped: () => { },
   onSwipedLeft: () => { },
   onSwipedRight: () => { },

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,8 @@ export interface CardStackProps {
   horizontalThreshold?: number;
   outputRotationRange?: [string, string, string]
   onSwipeStart?: (index: number) => void;
-  onSwipeEnd?: (index: number) => void; 
+  onSwipeEnd?: (index: number) => void;
+  onSwipeCancel?: () => void; 
   onSwiped?: (index: number) => void;
   onSwipedLeft?: (index: number) => void;
   onSwipedRight?: (index: number) => void;


### PR DESCRIPTION
This addresses [this case](https://github.com/lhandel/react-native-card-stack-swiper/issues/77#issuecomment-724990137) where it's useful to differentiate between the end of a successful swipe and a swipe that didn't meet the thresholds and led to  the card being reset. To do this it adds an `onSwipeCancel` method that works like `onSwipeEnd` except it only fires in the latter case.