### PR TITLE
Handle null card component

### DIFF
--- a/CardStack.js
+++ b/CardStack.js
@@ -161,7 +161,8 @@ class CardStack extends Component {
       }
       return true;
     }
-    if (a.key !== b.key) return false;
+    if(a !== null)
+      if (a.key !== b.key) return false;
 
     return true
   }


### PR DESCRIPTION
When clearing the cards inside the card stack, it returns null error on a.key. Added a null handler